### PR TITLE
🔧 fix(plugin): changed event to `INIT` in `getSubscribedEvents`

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -36,7 +36,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PluginEvents::PRE_COMMAND_RUN => ['onPreCommandRun', 1],
+            PluginEvents::INIT => ['onPreCommandRun', 1],
         ];
     }
 
@@ -91,15 +91,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     public function deactivate(Composer $composer, IOInterface $io): void
     {
         $this->io->write("<comment>WindowsExtIgnorerPlugin deactivated.</comment>");
-        
-        $this->applyPlatformOverrides();
     }
 
     public function uninstall(Composer $composer, IOInterface $io): void
     {
         $this->io->write("<comment>WindowsExtIgnorerPlugin uninstalled.</comment>");
         
-        $this->applyPlatformOverrides();
     }
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the plugin’s event triggering so it initiates earlier in the lifecycle, enhancing responsiveness.
	- Simplified deactivation and uninstallation, ensuring a more streamlined process by eliminating redundant configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->